### PR TITLE
Fix unwanted reloads by removing interactivity from account pages

### DIFF
--- a/Sample/Components/Account/Pages/Login.razor
+++ b/Sample/Components/Account/Pages/Login.razor
@@ -1,5 +1,5 @@
 ﻿@page "/Account/Login"
-@rendermode InteractiveServer
+
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity

--- a/Sample/Components/Account/Pages/Register.razor
+++ b/Sample/Components/Account/Pages/Register.razor
@@ -1,5 +1,5 @@
 ﻿@page "/Account/Register"
-@rendermode InteractiveServer
+
 @using System.ComponentModel.DataAnnotations
 @using System.Text
 @using System.Text.Encodings.Web

--- a/Sample/Components/App.razor
+++ b/Sample/Components/App.razor
@@ -11,12 +11,21 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
     <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js" type="text/javascript"></script>
-    <HeadOutlet />
+    <HeadOutlet @rendermode="@RenderModeForPage" />
 </head>
 
 <body>
-    <Routes />
+    <Routes @rendermode="@RenderModeForPage" />
     <script src="_framework/blazor.web.js"></script>
 </body>
 
 </html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+        ? null
+        : InteractiveServer;
+}

--- a/Sample/Components/Routes.razor
+++ b/Sample/Components/Routes.razor
@@ -1,5 +1,5 @@
 ﻿@using Sample.Components.Account.Shared
-@rendermode InteractiveServer
+
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">


### PR DESCRIPTION
If you look at the logic in AccountLayout.razor, you'll see that it's intentionally calling `NavigationManager.Refresh(forceReload: true)` to force a transition from dynamic back to static rendering. If you put a breakpoint there without these changes, you'll see it repeatedly get hit for reach reload.

https://github.com/Sureshrajan-18/Blazor_.NET8-AuthorizeRouteView/blob/cc0e4fd664addf40611dd0fff867803440f2955f/Sample/Components/Account/Shared/AccountLayout.razor#L22-L25

The account pages are intended to be used with static rendering where the `HttpContext` is available, so this PR makes the changes necessary to ensure account pages are statically rendered.